### PR TITLE
html: remove leading slash in package_name

### DIFF
--- a/src/luacov/reporter/multiple/html.lua
+++ b/src/luacov/reporter/multiple/html.lua
@@ -65,7 +65,7 @@ function HtmlReporter:on_new_file(filename)
 	if not package then
 		package = {
 			name = package_name,
-			report = package_name .. "/index",
+			report = package_name:gsub("^/", "") .. "/index",
 			["rate"] = 0,
 			["hits"] = 0,
 			["miss"] = 0,


### PR DESCRIPTION
I am seeing
`filename = /home/user/src/awesome/…/slider/value.lua`,
and `package_name` becomes `/home/user/src/awesome/…/slider`.
With the leading slash the link will contain two slashes, which results
in qutebrowser not finding it.