### PR TITLE
fix: html reporter collapses consecutive blank lines

### DIFF
--- a/src/luacov/multiple/templatefile.lua
+++ b/src/luacov/multiple/templatefile.lua
@@ -42,7 +42,7 @@ return [[
             </div>
             <div class="code">
                 {{#lines}}
-                <div class="line" data-hits="{{hits}}">{{line}}</div>
+                <div class="line" data-hits="{{hits}}">{{line}}&#8203;</div>
                 {{/lines}}
             </div>
         </div>


### PR DESCRIPTION
fix for #7 . It's ugly but it works.