### PR TITLE
Fix configuration default handling

### DIFF
--- a/src/luacov/reporter/multiple/cobertura.lua
+++ b/src/luacov/reporter/multiple/cobertura.lua
@@ -11,7 +11,7 @@ local CoberturaReporter = setmetatable({}, ReporterBase) do
 CoberturaReporter.__index = CoberturaReporter
 
 function CoberturaReporter:new(conf)
-	local confOver = conf.multiple.cobertura and conf.multiple.cobertura or {}
+	local confOver = conf.multiple and conf.multiple.cobertura or {}
 
 	local config = {}
 	for k, v in pairs(conf) do

--- a/src/luacov/reporter/multiple/html.lua
+++ b/src/luacov/reporter/multiple/html.lua
@@ -18,12 +18,22 @@ local HtmlReporter = setmetatable({}, ReporterBase) do
 HtmlReporter.__index = HtmlReporter
 
 function HtmlReporter:new(conf)
-	local confOver = conf.multiple.html and conf.multiple.html or {}
-	confOver.reportfile = confOver.reportfile and confOver.reportfile or 'luacov_html/index.html'
+	local confOver = conf.multiple and conf.multiple.html or {}
+	confOver.reportfile = confOver.reportfile or 'luacov_html/index.html'
 
 	local config = {}
 	for k, v in pairs(conf) do
 		config[k] = confOver[k] and confOver[k] or v
+	end
+
+	local reportDir = string.gsub(config.reportfile, "(.*[/\\])(.*)", "%1")
+	local separator = string.match(reportDir, "[/\\]")
+	if separator then
+		local dirPath = ""
+		for dir in string.gmatch(reportDir, "[^/\\]+") do
+			dirPath = dirPath .. dir .. separator
+			lfs.mkdir(dirPath)
+		end
 	end
 
 	local o, err = ReporterBase.new(self, config)
@@ -31,7 +41,7 @@ function HtmlReporter:new(conf)
 		return nil, err
 	end
 
-	o.reportDir = string.gsub(config.reportfile, "(.*[/\\])(.*)", "%1")
+	o.reportDir = reportDir
 
 	return o
 end


### PR DESCRIPTION
Running without a config file set up for luaconfig-multiple resulted in errors instead of using default values. This pull request fixes the logic for falling back to default when no configuration is specified.

Also added logic to create the parent directory for the html report if it doesn't exist instead of throwing a file not found error.

Tested with and without config file using:
 * `luacov -r multiple.html`
 * `luacov -r multiple.cobertura`
